### PR TITLE
feat: 'make multi' to build and push multiarch docker image with arm64,amd64,arm archs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
+FROM golang:1.23-bookworm AS build
+
+WORKDIR /go/src/app
+RUN --mount=target=. make build
+
 FROM quay.io/prometheus/busybox:latest
 
-ADD prometheus-example-app /bin/prometheus-example-app
+COPY --from=build /tmp/prometheus-example-app /bin/prometheus-example-app
 
 ENTRYPOINT ["/bin/prometheus-example-app"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ VERSION:=$(shell cat VERSION)
 
 LDFLAGS="-X main.appVersion=$(VERSION)"
 
-all:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags=$(LDFLAGS) -o prometheus-example-app --installsuffix cgo main.go
+build:
+	CGO_ENABLED=0 go build -ldflags=$(LDFLAGS) -o /tmp/prometheus-example-app --installsuffix cgo main.go
+
+all: build
 	docker build -t quay.io/brancz/prometheus-example-app:$(VERSION) .
+
+multi: build
+	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t quay.io/brancz/prometheus-example-app:$(VERSION) .


### PR DESCRIPTION
Hi, thanks for your work.

I use arm64 based k8s and following the tutorial at https://prometheus-operator.dev/docs/developer/getting-started/#deploying-a-sample-application

I got an issue that the image in question cannot be run on my node because:

```
$ kubectl logs deployments/example-app --all-pods --prefix -f
[pod/example-app-5ffc85cf6d-96r92/example-app] exec /bin/prometheus-example-app: exec format error
[pod/example-app-5ffc85cf6d-98r8x/example-app] exec /bin/prometheus-example-app: exec format error
[pod/example-app-5ffc85cf6d-vkv96/example-app] exec /bin/prometheus-example-app: exec format error
```

This patch intoduces a new Makefile `multi` which builds and pushes a multiarch image to quay.io/brancz/prometheus-example-app:v0.5.0 .
If you want to test it locally without pushing, run `make multi` with this patch:

```bash
$ git diff
diff --git a/Makefile b/Makefile
index e2970a9..a2ecd85 100644
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ all: build
        docker build -t quay.io/brancz/prometheus-example-app:$(VERSION) .

 multi: build
-       docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t quay.io/brancz/prometheus-example-app:$(VERSION) .
+       docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t quay.io/brancz/prometheus-example-app:$(VERSION) .
```
